### PR TITLE
Save progress auto

### DIFF
--- a/app/viewmodels/exitCourse.js
+++ b/app/viewmodels/exitCourse.js
@@ -41,7 +41,7 @@
         }
 
         function close() {
-            if (progressContext.status() === progressStatuses.saved) {
+            if (progressContext.status() !== progressStatuses.error) {
                 windowOperations.close();
             } else if (progressContext.status() === progressStatuses.error && confirm(translation.getTextByKey('[progress is not saved confirmation]'))) {
                 progressContext.status(progressStatuses.ignored);

--- a/app/viewmodels/exitCourse.js
+++ b/app/viewmodels/exitCourse.js
@@ -41,12 +41,15 @@
         }
 
         function close() {
-            if (progressContext.status() !== progressStatuses.error) {
-                windowOperations.close();
-            } else if (progressContext.status() === progressStatuses.error && confirm(translation.getTextByKey('[progress is not saved confirmation]'))) {
-                progressContext.status(progressStatuses.ignored);
-                windowOperations.close();
+            if (progressContext.status() === progressStatuses.error) {
+                if (confirm(translation.getTextByKey('[progress is not saved confirmation]'))) {
+                    progressContext.status(progressStatuses.ignored);
+                } else {
+                    return;
+                }
             }
+
+            windowOperations.close();
         }
 
         function finish() {

--- a/app/viewmodels/exitCourse.js
+++ b/app/viewmodels/exitCourse.js
@@ -42,11 +42,11 @@
 
         function close() {
             if (progressContext.status() === progressStatuses.error) {
-                if (confirm(translation.getTextByKey('[progress is not saved confirmation]'))) {
-                    progressContext.status(progressStatuses.ignored);
-                } else {
+                var isCourseClosingConfirmed = confirm(translation.getTextByKey('[progress is not saved confirmation]'));
+                if (!isCourseClosingConfirmed) {
                     return;
                 }
+                progressContext.status(progressStatuses.ignored);
             }
 
             windowOperations.close();


### PR DESCRIPTION
 It was not possible to close course when progress hasn't been saved yet:
-Set simple course template
-Disable reporting results
-Open course
-Try to close using "Save and continue later" - course is not closed.